### PR TITLE
update map path handling to support arbitrary map directories

### DIFF
--- a/src/navigation/navigation.cc
+++ b/src/navigation/navigation.cc
@@ -189,7 +189,11 @@ struct GraphVisualizer {
 
 namespace navigation {
 
-Navigation::Navigation(const string& map_file, ros::NodeHandle* n) :
+inline string GetMapPath(const string& dir, const string& name) {
+  return dir + "/" + name + "/" + name + ".vectormap.txt";
+}
+
+Navigation::Navigation(const string& maps_dir, const string& map_name, ros::NodeHandle* n) :
     robot_loc_(0, 0),
     robot_angle_(0),
     robot_vel_(0, 0),
@@ -206,7 +210,8 @@ Navigation::Navigation(const string& map_file, ros::NodeHandle* n) :
     kRearAxleOffset(0),
     kMaxFreeLength(6),
     kMaxClearance(1.0),
-    planning_domain_(map_file),
+    maps_dir_(maps_dir),
+    planning_domain_(GetMapPath(maps_dir, map_name)),
     enabled_(false) {
   ackermann_drive_pub_ = n->advertise<AckermannCurvatureDriveMsg>(
       "ackermann_curvature_drive", 1);
@@ -242,8 +247,8 @@ void Navigation::SetNavGoal(const Vector2f& loc, float angle) {
   plan_path_.clear();
 }
 
-void Navigation::UpdateMap(const string& map_file) {
-  planning_domain_.Load(map_file);
+void Navigation::UpdateMap(const string& map_name) {
+  planning_domain_.Load(GetMapPath(maps_dir_, map_name));
   plan_path_.clear();
 }
 

--- a/src/navigation/navigation.cc
+++ b/src/navigation/navigation.cc
@@ -190,7 +190,7 @@ struct GraphVisualizer {
 namespace navigation {
 
 inline string GetMapPath(const string& dir, const string& name) {
-  return dir + "/" + name + "/" + name + ".vectormap.txt";
+  return dir + "/" + name + "/" + name + ".navigation.txt";
 }
 
 Navigation::Navigation(const string& maps_dir, const string& map_name, ros::NodeHandle* n) :

--- a/src/navigation/navigation.h
+++ b/src/navigation/navigation.h
@@ -54,7 +54,7 @@ struct PathOption {
 
 class Navigation {
  public:
-  explicit Navigation(const std::string& map_file, ros::NodeHandle* n);
+  explicit Navigation(const std::string& maps_dir, const std::string& map_name, ros::NodeHandle* n);
   void UpdateMap(const std::string& map_file);
   void UpdateLocation(const Eigen::Vector2f& loc, float angle);
   void UpdateOdometry(const nav_msgs::Odometry& msg);
@@ -167,6 +167,8 @@ class Navigation {
   const float kMaxFreeLength;
   // Maximum clearance for the robot to care about.
   const float kMaxClearance;
+
+  const std::string maps_dir_;
 
   // Planning domain for A* planner.
   GraphDomain planning_domain_;

--- a/src/navigation/navigation_main.cc
+++ b/src/navigation/navigation_main.cc
@@ -72,8 +72,11 @@ DEFINE_string(init_topic,
 DEFINE_string(enable_topic, "autonomy_arbiter/enabled",
     "ROS topic that indicates whether autonomy is enabled or not.");
 DEFINE_string(map,
-              "maps/Joydeepb-Home/Joydeepb-Home.navigation.txt",
-              "Name of navigation map file");
+              "Joydeepb-Home",
+              "Name of navigation map");
+DEFINE_string(maps_dir,
+              "maps",
+              "Path to the directory containing navigati onmaps");
 DECLARE_string(helpon);
 DECLARE_int32(v);
 DECLARE_double(dt);
@@ -182,7 +185,7 @@ int main(int argc, char** argv) {
   // Initialize ROS.
   ros::init(argc, argv, "navigation", ros::init_options::NoSigintHandler);
   ros::NodeHandle n;
-  navigation_ = new Navigation(FLAGS_map, &n);
+  navigation_ = new Navigation(FLAGS_maps_dir, FLAGS_map, &n);
 
   ros::Subscriber velocity_sub =
       n.subscribe(FLAGS_odom_topic, 1, &OdometryCallback);

--- a/src/navigation/navigation_main.cc
+++ b/src/navigation/navigation_main.cc
@@ -72,7 +72,7 @@ DEFINE_string(init_topic,
 DEFINE_string(enable_topic, "autonomy_arbiter/enabled",
     "ROS topic that indicates whether autonomy is enabled or not.");
 DEFINE_string(map,
-              "Joydeepb-Home",
+              "UT_Campus",
               "Name of navigation map");
 DEFINE_string(maps_dir,
               "maps",


### PR DESCRIPTION
This is necessary for use of `graph_navigation` as a part of the ut_jackal repo, and for launching it via a `.launch` file.

This also fixes the case where localization sends a new map name, because we now will correctly load the new map