### PR TITLE
Fix goto callback

### DIFF
--- a/src/navigation/navigation_main.cc
+++ b/src/navigation/navigation_main.cc
@@ -141,10 +141,13 @@ void GoToCallbackPS(const geometry_msgs::PoseStamped& msg) {
   navigation_->SetNavGoal(loc, angle);
 }
 
-void GoToCallback(const amrl_msgs::Pose2Df& msg) {
-  const Vector2f loc(msg.x, msg.y);
-  printf("Goal: (%f,%f) %f\u00b0\n", loc.x(), loc.y(), msg.theta);
-  navigation_->SetNavGoal(loc, msg.theta);
+void GoToCallback(const geometry_msgs::PoseStamped& msg) {
+  const Vector2f loc(msg.pose.position.x, msg.pose.position.y);
+  const float theta = 2.0 * atan2(
+      msg.pose.orientation.z, msg.pose.orientation.w);
+  printf("Goal: (%f,%f) %f\u00b0\n", loc.x(), loc.y(), 
+      math_util::RadToDeg(theta));
+  navigation_->SetNavGoal(loc, theta);
 }
 
 


### PR DESCRIPTION
This fix is supposed to make it so that the navigation goto callback uses the standard ROS format for move_base/goto callback.