### PR TITLE
graph navigation will now use config to avoid stairs as necessary

### DIFF
--- a/config/navigation.lua
+++ b/config/navigation.lua
@@ -1,6 +1,6 @@
 NavigationParameters = {
   laser_topic = "velodyne_2dscan";
-  odom_topic = "odom";
+  odom_topic = "jackal_velocity_controller/odom";
   localization_topic = "localization";
   init_topic = "initialpose";
   enable_topic = "autonomy_arbiter/enabled";

--- a/config/navigation.lua
+++ b/config/navigation.lua
@@ -1,6 +1,6 @@
 NavigationParameters = {
   laser_topic = "velodyne_2dscan";
-  odom_topic = "jackal_velocity_controller/odom";
+  odom_topic = "odom";
   localization_topic = "localization";
   init_topic = "initialpose";
   enable_topic = "autonomy_arbiter/enabled";
@@ -24,4 +24,5 @@ NavigationParameters = {
   base_link_offset = 0;
   max_free_path_length = 6.0;
   max_clearance = 1.0;
+  can_traverse_stairs = false;
 };

--- a/src/navigation/navigation.cc
+++ b/src/navigation/navigation.cc
@@ -202,7 +202,8 @@ void Navigation::Initialize(const NavigationParameters& params,
   status_msg_.text = "Navigation Status";
   InitRosHeader("base_link", &drive_msg_.header);
   InitRosHeader("base_link", &fp_pcl_msg_.header);
-  planning_domain_ = GraphDomain(map_file);
+  params_ = params;
+  planning_domain_ = GraphDomain(map_file, &params_);
   initialized_ = true;
 }
 

--- a/src/navigation/navigation.h
+++ b/src/navigation/navigation.h
@@ -30,6 +30,7 @@
 #include "config_reader/config_reader.h"
 #include "eight_connected_domain.h"
 #include "graph_domain.h"
+#include "navigation_parameters.h"
 
 #ifndef NAVIGATION_H
 #define NAVIGATION_H
@@ -39,69 +40,6 @@ namespace ros {
 }  // namespace ros
 
 namespace navigation {
-
-struct MotionLimit {
-  // Maximum permissible acceleration magnitude.
-  // NOTE: Must be positive!
-  float accel;
-  // Maximum permissible deceleration magnitude.
-  // NOTE: Must be positive!
-  float decel;
-  // Maximum permissible speed.
-  float speed;
-
-  // Default constructor: set all to zero.
-  MotionLimit() : accel(0), decel(0), speed(0) {}
-
-  // Convenience constructor: init values.
-  MotionLimit(float accel, float decel, float speed) :
-      accel(accel), decel(decel), speed(speed) {}
-};
-
-struct NavigationParameters {
-  // Control period in seconds.
-  double dt;
-  // Motion limits for linear motion.
-  MotionLimit linear_limits;
-  // Motion limits for angular motion.
-  MotionLimit angular_limits;
-  // Distance of carrot from robot to compute local planner goal from
-  // global plan.
-  float carrot_dist;
-  // System latency in seconds, including sensing latency, processing latency,
-  // and actuation latency.
-  float system_latency;
-  // Safety obstacle margin around the robot.
-  float obstacle_margin;
-  // Number of options to consider for the local planner.
-  unsigned int num_options;
-  // Width of the robot.
-  float robot_width;
-  // Length of the robot.
-  float robot_length;
-  // Location of the base link w.r.t. the center of the robot.
-  // Negative values indicate that the base link is closer to the rear of the
-  // robot, for example on a car with ackermann steering, with its base link
-  // coincident with its rear axle.
-  float base_link_offset;
-  float max_free_path_length;
-  float max_clearance;
-
-  // Default constructor, just set defaults.
-  NavigationParameters() :
-      dt(0.025),
-      linear_limits(0.5, 0.5, 0.5),
-      angular_limits(0.5, 0.5, 1.0),
-      carrot_dist(2.5),
-      system_latency(0.24),
-      obstacle_margin(0.15),
-      num_options(41),
-      robot_width(0.44),
-      robot_length(0.5),
-      base_link_offset(0),
-      max_free_path_length(6.0),
-      max_clearance(1.0) {}
-};
 
 inline std::string GetMapPath(const std::string& dir, const std::string& name) {
   return dir + "/" + name + "/" + name + ".navigation.json";

--- a/src/navigation/navigation_main.cc
+++ b/src/navigation/navigation_main.cc
@@ -171,6 +171,7 @@ void LoadConfig(navigation::NavigationParameters* params) {
   #define REAL_PARAM(x) CONFIG_DOUBLE(x, "NavigationParameters."#x);
   #define NATURALNUM_PARAM(x) CONFIG_UINT(x, "NavigationParameters."#x);
   #define STRING_PARAM(x) CONFIG_STRING(x, "NavigationParameters."#x);
+  #define BOOL_PARAM(x) CONFIG_BOOL(x, "NavigationParameters."#x);
   REAL_PARAM(dt);
   REAL_PARAM(max_linear_accel);
   REAL_PARAM(max_linear_decel);
@@ -187,6 +188,7 @@ void LoadConfig(navigation::NavigationParameters* params) {
   REAL_PARAM(base_link_offset);
   REAL_PARAM(max_free_path_length);
   REAL_PARAM(max_clearance);
+  BOOL_PARAM(can_traverse_stairs);
 
   config_reader::ConfigReader reader({FLAGS_robot_config});
   params->dt = CONFIG_dt;
@@ -207,6 +209,7 @@ void LoadConfig(navigation::NavigationParameters* params) {
   params->base_link_offset = CONFIG_base_link_offset;
   params->max_free_path_length = CONFIG_max_free_path_length;
   params->max_clearance = CONFIG_max_clearance;
+  params->can_traverse_stairs = CONFIG_can_traverse_stairs;
 }
 
 int main(int argc, char** argv) {

--- a/src/navigation/navigation_parameters.h
+++ b/src/navigation/navigation_parameters.h
@@ -1,0 +1,99 @@
+//========================================================================
+//  This software is free: you can redistribute it and/or modify
+//  it under the terms of the GNU Lesser General Public License Version 3,
+//  as published by the Free Software Foundation.
+//
+//  This software is distributed in the hope that it will be useful,
+//  but WITHOUT ANY WARRANTY; without even the implied warranty of
+//  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+//  GNU Lesser General Public License for more details.
+//
+//  You should have received a copy of the GNU Lesser General Public License
+//  Version 3 in the file COPYING that came with this distribution.
+//  If not, see <http://www.gnu.org/licenses/>.
+//========================================================================
+/*!
+\file    navigation.h
+\brief   Interface for reference Navigation class.
+\author  Joydeep Biswas, (C) 2019
+*/
+//========================================================================
+
+#include <vector>
+
+#ifndef NAVIGATION_PARAMETERS_H
+#define NAVIGATION_PARAMETERS_H
+
+#include "config_reader/config_reader.h"
+
+namespace navigation {
+
+struct MotionLimit {
+  // Maximum permissible acceleration magnitude.
+  // NOTE: Must be positive!
+  float accel;
+  // Maximum permissible deceleration magnitude.
+  // NOTE: Must be positive!
+  float decel;
+  // Maximum permissible speed.
+  float speed;
+
+  // Default constructor: set all to zero.
+  MotionLimit() : accel(0), decel(0), speed(0) {}
+
+  // Convenience constructor: init values.
+  MotionLimit(float accel, float decel, float speed) :
+      accel(accel), decel(decel), speed(speed) {}
+};
+
+struct NavigationParameters {
+  // Control period in seconds.
+  double dt;
+  // Motion limits for linear motion.
+  MotionLimit linear_limits;
+  // Motion limits for angular motion.
+  MotionLimit angular_limits;
+  // Distance of carrot from robot to compute local planner goal from
+  // global plan.
+  float carrot_dist;
+  // System latency in seconds, including sensing latency, processing latency,
+  // and actuation latency.
+  float system_latency;
+  // Safety obstacle margin around the robot.
+  float obstacle_margin;
+  // Number of options to consider for the local planner.
+  unsigned int num_options;
+  // Width of the robot.
+  float robot_width;
+  // Length of the robot.
+  float robot_length;
+  // Location of the base link w.r.t. the center of the robot.
+  // Negative values indicate that the base link is closer to the rear of the
+  // robot, for example on a car with ackermann steering, with its base link
+  // coincident with its rear axle.
+  float base_link_offset;
+  float max_free_path_length;
+  float max_clearance;
+
+  bool can_traverse_stairs;
+
+  // Default constructor, just set defaults.
+  NavigationParameters() :
+      dt(0.025),
+      linear_limits(0.5, 0.5, 0.5),
+      angular_limits(0.5, 0.5, 1.0),
+      carrot_dist(2.5),
+      system_latency(0.24),
+      obstacle_margin(0.15),
+      num_options(41),
+      robot_width(0.44),
+      robot_length(0.5),
+      base_link_offset(0),
+      max_free_path_length(6.0),
+      max_clearance(1.0),
+      can_traverse_stairs(false) {}
+};
+
+}  // namespace navigation
+
+#endif  // NAVIGATION_PARAMETERS_H

--- a/src/navigation/navigation_parameters.h
+++ b/src/navigation/navigation_parameters.h
@@ -13,8 +13,8 @@
 //  If not, see <http://www.gnu.org/licenses/>.
 //========================================================================
 /*!
-\file    navigation.h
-\brief   Interface for reference Navigation class.
+\file    navigation_parameters.h
+\brief   Interface for Navigation parameters as loaded from config.
 \author  Kavan Sikand, (C) 2020
 */
 //========================================================================

--- a/src/navigation/navigation_parameters.h
+++ b/src/navigation/navigation_parameters.h
@@ -15,7 +15,7 @@
 /*!
 \file    navigation.h
 \brief   Interface for reference Navigation class.
-\author  Joydeep Biswas, (C) 2019
+\author  Kavan Sikand, (C) 2020
 */
 //========================================================================
 


### PR DESCRIPTION
Added stair traversibility to the navigation config, and made graph_nav only present edges that are traversible to the A-Star global planner.

The goal here is to be able to do away with the UT_Campus_With_Stairs map, since we can just add the correct edge annotation to the UT_Campus map, and everything should work nicely.

I validated that the planner does in fact present only the edges that are valid for both cases.