### PR TITLE
add support for amrl message types, add query topics to do planning

### DIFF
--- a/src/navigation/navigation.cc
+++ b/src/navigation/navigation.cc
@@ -549,14 +549,14 @@ void Navigation::ObservePointCloud(const vector<Vector2f>& cloud,
   PruneLatencyQueue();
 }
 
-void Navigation::Plan() {
+void Navigation::Plan(Eigen::Vector2f goal_loc) {
   static CumulativeFunctionTimer function_timer_(__FUNCTION__);
   CumulativeFunctionTimer::Invocation invoke(&function_timer_);
   static const bool kVisualize = true;
   typedef navigation::GraphDomain Domain;
   planning_domain_.ResetDynamicStates();
   const uint64_t start_id = planning_domain_.AddDynamicState(robot_loc_);
-  const uint64_t goal_id = planning_domain_.AddDynamicState(nav_goal_loc_);
+  const uint64_t goal_id = planning_domain_.AddDynamicState(goal_loc);
   Domain::State start = planning_domain_.states[start_id];
   Domain::State goal = planning_domain_.states[goal_id];
   visualization::ClearVisualizationMsg(global_viz_msg_);
@@ -583,7 +583,7 @@ void Navigation::Plan() {
 
 void Navigation::PlannerTest() {
   if (!loc_initialized_) return;
-  Plan();
+  Plan(nav_goal_loc_);
 }
 
 DEFINE_double(max_plan_deviation, 0.5,
@@ -1178,7 +1178,7 @@ void Navigation::Run() {
   status_msg_.status = 1;
   status_pub_.publish(status_msg_);
   if (!PlanStillValid()) {
-    Plan();
+    Plan(nav_goal_loc_);
   }
   // Get Carrot.
   const Vector2f carrot = GetCarrot();

--- a/src/navigation/navigation.h
+++ b/src/navigation/navigation.h
@@ -81,7 +81,7 @@ class Navigation {
                          Eigen::Vector2f* obstruction);
   void SetNavGoal(const Eigen::Vector2f& loc, float angle);
   bool PlanStillValid();
-  void Plan();
+  void Plan(Eigen::Vector2f goal_loc);
   Eigen::Vector2f GetCarrot();
   // Enable or disable autonomy.
   void Enable(bool enable);

--- a/src/navigation/navigation_main.cc
+++ b/src/navigation/navigation_main.cc
@@ -142,6 +142,24 @@ void GoToCallback(const geometry_msgs::PoseStamped& msg) {
   navigation_.SetNavGoal(loc, angle);
 }
 
+void GoToCallbackAMRL(const amrl_msgs::Localization2DMsg& msg) {
+  const Vector2f loc(msg.pose.x, msg.pose.y);
+  printf("Goal: (%f,%f) %f\u00b0\n", loc.x(), loc.y(), msg.pose.theta);
+  navigation_.SetNavGoal(loc, msg.pose.theta);
+}
+
+void QueryCallback(const geometry_msgs::PoseStamped& msg) {
+  const Vector2f loc(msg.pose.position.x, msg.pose.position.y);
+  printf("Queried Plan for Goal: (%f,%f)\n", loc.x(), loc.y());
+  navigation_.Plan(loc);
+}
+
+void QueryCallbackAMRL(const amrl_msgs::Localization2DMsg& msg) {
+  const Vector2f loc(msg.pose.x, msg.pose.y);
+  printf("Queried Plan for Goal: (%f,%f)\n", loc.x(), loc.y());
+  navigation_.Plan(loc);
+}
+
 void SignalHandler(int) {
   if (!run_) {
     printf("Force Exit.\n");
@@ -242,6 +260,12 @@ int main(int argc, char** argv) {
       n.subscribe(CONFIG_laser_topic, 1, &LaserCallback);
   ros::Subscriber goto_sub =
       n.subscribe("/move_base_simple/goal", 1, &GoToCallback);
+  ros::Subscriber goto_amrl_sub =
+      n.subscribe("/move_base_simple/goal_amrl", 1, &GoToCallbackAMRL);
+  ros::Subscriber query_sub =
+      n.subscribe("/query_simple/goal", 1, &QueryCallback);
+  ros::Subscriber query_amrl_sub =
+      n.subscribe("/query_simple/goal_amrl", 1, &QueryCallbackAMRL);
   ros::Subscriber enabler_sub =
       n.subscribe(CONFIG_enable_topic, 1, &EnablerCallback);
   ros::Subscriber halt_sub =


### PR DESCRIPTION
I feel that graph_navigation should be able to take in amrl Localization2dMsg messages as target goals, so this adds that.

Additionally, this adds a "planning-only" topic to which you can send a goal location and get the global plan (which gets published via the normal trajectory topic), without actually sending the robot anywhere. This is going to be leveraged by the SMADS team for the higher-level planner, which will use this trajectory to decide on a better short-term goal for graph_navigation.