### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@
 1. [glog](https://github.com/google/glog)
 1. [gflags](https://github.com/gflags/gflags)
 1. [Lua5.1](http://www.lua.org/)
-1. [LibTorch](https://pytorch.org/get-started/locally/): Unpack the libtorch zip
+1. [LibTorch](https://pytorch.org/get-started/locally/): Requires the cxx11 ABI version libtorch. Unpack the libtorch zip
    file to `/opt/libtorch`.
 
 You can install the system dependencies on *buntu using:


### PR DESCRIPTION
If you use the other libtorch option, you get arcane errors that are very difficult to debug because the linker fails on everything but libtorch.